### PR TITLE
expose IGetGPUTier in the bundle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { getLevenshteinDistance } from './internal/getLevenshteinDistance';
 
 // Types
 import { IGetGPUTier, TRank, IRankWithDistance } from './types';
+export { IGetGPUTier };
 
 export const getGPUTier = ({
   mobileBenchmarkPercentages = [


### PR DESCRIPTION
IGetGPUTier was not exported from v1.5 (fdf5e6925a0e943ef1b05419126ce922e02ccabd). It's needed for strict checks in TS.